### PR TITLE
Docker image to host cSpot

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,98 @@
+FROM ubuntu:16.04
+MAINTAINER Chris Walsh <chris24walsh@gmail.com>
+LABEL Description="LAMP stack for the cSpot (Church Services Online Planning Tool), based on Ubuntu 16.04 LTS. Includes dependencies, such as PHP7.2 and composer. Derived from the generic PHP 7.0 LAMP stack image maintained at fauria/lamp, https://hub.docker.com/r/fauria/lamp/dockerfile" \
+    License="Apache License 2.0" \
+    Version="1.0"
+
+
+### Install project dependencies
+
+# Update/upgrade apt packages
+RUN apt-get update && apt-get upgrade -y
+
+# Install repo required for php7.2
+RUN apt-get install -y python-software-properties software-properties-common apt-utils \
+    && LC_ALL=C.UTF-8 add-apt-repository ppa:ondrej/php \
+    && apt-get update
+
+# Install php7.2 and plugins
+RUN apt-get install -y \
+    php7.2 \
+    php7.2-bz2 \
+    php7.2-cgi \
+    php7.2-cli \
+    php7.2-common \
+    php7.2-curl \
+    php7.2-dev \
+    php7.2-enchant \
+    php7.2-fpm \
+    php7.2-gd \
+    php7.2-gmp \
+    php7.2-imap \
+    php7.2-interbase \
+    php7.2-intl \
+    php7.2-json \
+    php7.2-ldap \
+    php7.2-mbstring \
+    php7.1-mcrypt \
+    php7.2-mysql \
+    php7.2-odbc \
+    php7.2-opcache \
+    php7.2-pgsql \
+    php7.2-phpdbg \
+    php7.2-pspell \
+    php7.2-readline \
+    php7.2-recode \
+    php7.2-snmp \
+    php7.2-sqlite3 \
+    php7.2-sybase \
+    php7.2-tidy \
+    php7.2-xmlrpc \
+    php7.2-xsl \
+    php7.2-zip
+
+# Install apache, mysql and composer
+RUN apt-get install -y apache2 libapache2-mod-php7.2 \
+    mariadb-common mariadb-server mariadb-client \
+    composer
+
+
+### Install cSpot
+
+# Copy the project to the apache root directory
+COPY ./ /var/www/html/cSpot/
+
+# Set the project working directory
+WORKDIR /var/www/html/cSpot
+
+# (???) Have to copy the below folder from lower-case to upper-case, since it is referenced as upper-case in the project files
+RUN cp -r app/ App/
+
+# Create mysql database/user and initialise the db
+RUN service mysql start \
+    && cat docker/cspot-mysql.sql | mysql \
+    && cp docker/.env .env \
+    && composer install \
+    && php artisan key:generate \
+    && echo "admin@example.com" | php artisan migrate
+
+# Set up project for Apache and create Virtualhost for cspot
+RUN cp docker/cspot-apache.conf /etc/apache2/sites-available \
+    && chown -R www-data:www-data ./ \
+    && chmod -R 755 ./storage \
+    && a2dissite 000-default.conf \
+    && a2ensite cspot-apache.conf \
+    && a2enmod rewrite \
+    && service apache2 restart
+
+
+### Start the app
+
+# Open port 80 for the webserver
+EXPOSE 80
+
+# Start mysql, apache, set the administrator password if supplied, and tail the logs (to keep the container shell open)
+CMD service mysql start \
+    && if [ $admin_email ]; then echo "update cspot.users set email='${admin_email}' where id=1;" | mysql; fi \
+    && service apache2 start \
+    && tail -f /var/log/apache2/*

--- a/docker/cspot-apache.conf
+++ b/docker/cspot-apache.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+    ServerName cSpot
+
+    ServerAdmin admin@example.com
+    DocumentRoot /var/www/html/cSpot/public
+
+    <Directory /var/www/html/cSpot>
+        AllowOverride All
+    </Directory>
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+</VirtualHost>

--- a/docker/cspot-mysql.sql
+++ b/docker/cspot-mysql.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE cspot;
+GRANT ALL PRIVILEGES ON *.* TO 'homestead'@'localhost' IDENTIFIED BY 'secret';

--- a/readme.md
+++ b/readme.md
@@ -150,6 +150,54 @@ Out of the box, c-SPOT uses a mySQL database to save all the data. However, Lara
 In order to develop (program) c-SPOT, you need to have learned some Laravel development basics. Node.js and NPM need to be installed, then run "NPM install" to have all the assets available. 
 Check https://laravel.com/docs/5.3/elixir for further information.
 
+#### Easy installation, using Docker
+You can instead do an easy, quick installation of cSpot in an isolated Docker container. Docker allows you to run multiple, preconfigured, isolated application environments which don't require any set up, and won't conflict with each other or your host machine operating system. This is terrific for running a development environment requiring a specific set of dependenciees, packages and libraries, or allowing an application such as cSpot to be portable on many kinds of production servers without reconfiguration.
+
+##### Basic use
+You will need Docker installed in your host machine (available for Linux, OSX and Windows), and to ensure that the Docker service/daemon is running. For help installing and starting Docker, vist https://docs.docker.com/get-docker/. Then, to start a cSpot Docker container, simply run the following in your command line/terminal (you may have to prefix the command with `sudo` in Linux):
+
+- `docker run -i -t -d -p 8080:80 --rm -e admin_email=<your-email-here> chris24walsh\cspot-ubuntu`
+
+This command will download a ready-made default image from https://hub.docker.com with cSpot fully installed, start a new docker container, configure your supplied email as the adminstrator email in cSpot and start cSpot itself along with apache2 and mysql. You can then access your local cSpot app in your browser by visiting http://localhost:8080/login, and gain access by resetting your administrator user password, sent to the email you provided. Everything you need to begin using and testing cSpot for yourself in one command!
+
+*Warning:* This pre-built image uses the default settings for mysql details e.g. database, user/password, and any other required parameters. Don't use this image and expose your server to the internet - build your own image with the commmands below after you have set unique values for the required parameters in the configuration files in the projects docker/ directory.
+
+You can remove the -d flag from the command if you want to stay attached to the (psuedo)terminal in the container, and see the output from the apache log files - useful for testing a connection. If you remove the `-e admin_email=<your-email-here>` parameter, the container will use the default admin email `admin@example.com` as configured in the Dockerfile.
+
+##### Building and running a custom image 
+To build a new image, including any modifications you have made to your local project directory, and run it, run the following commands:
+
+- `docker build -t <your-image-name-here> .`
+
+- `docker run -itdp 8080:80 --rm <your-image-name-here>`
+
+The first command builds a new local image, with the name tag <your-image-name-here>. The command must be run in the same directory as the Dockerfile, in the root of the project.
+
+The second command runs the <your-image-name-here> image in a new container, and, using the -p flag, exposes the containers port 80 to the host machines port 8080. The -d flag in the command launches the container in detached mode, so it will run in the background. The -i and -t flags allow the container to be attached to later, with a terminal to run commands.
+
+Before the above commands are run, you should change the default values in the docker/* files as appropriate, and the default administrator email address in line 77 in the Dockerfile.
+
+##### More commands
+To see your running containers, you can run:
+
+- `docker ps`
+
+Note the id for the cspot-ubuntu container, and stop it by running:
+
+- `docker stop <id>`
+
+You can start it again using:
+
+- `docker start <id>`
+
+You can connect to a detached container using:
+
+- `docker exec -it <id> /bin/bash`
+
+You can detach from a container, but leave it running, by pressing the key sequence CTRL+p, CTRL+q.
+
+For more information about using docker, type `docker help`, or visit 'https://docs.docker.com/get-started/'
+
 ### Future Enhancements (c-SPOT 2.0)
 
 - Pre-populate the songs database with popular **public domain** lyrics


### PR DESCRIPTION
Created a Dockerfile for building a Docker image which can host cSpot.
It includes the dependencies required by the cSpot project, not all of
these were apparent in the project documentation - particularly a (seeming) error in the naming of a
app directory, app/, which was referenced in the code as App/ instead.
Since it took me some time to work out how to install the project
correctly, I thought it would be helpful to write this Dockerfile to
simplify the process for other users/developers. Plus, Docker is awesome :)

I've included some instructions in the readme, to get started with
running the docker container.