### PR TITLE
Integrate ci to laravael 5.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,33 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a single command using the runners shell
+    - name: Run a one-line script
+      run: echo Hello, world!
+
+    # Runs a set of commands using the runners shell
+    - name: Run a multi-line script
+      run: |
+        echo Add other actions to build,
+        echo test, and deploy your project.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,57 +22,6 @@ jobs:
     - uses: actions/checkout@v2
 
     # Runs a set of commands using the runners shell
-    - name: Run a multi-line script
+    - name: Do a docker build
       run: |
-        # Update apt and add needed repository
-        sudo apt-get update && sudo apt-get upgrade -y
-        sudo apt-get install -y python-software-properties software-properties-common apt-utils \
-          && LC_ALL=C.UTF-8 sudo add-apt-repository ppa:ondrej/php \
-          && sudo apt-get update
-        # Install project dependencies
-        sudo apt-get install -y \
-          php7.2 \
-          php7.2-bz2 \
-          php7.2-cgi \
-          php7.2-cli \
-          php7.2-common \
-          php7.2-curl \
-          php7.2-dev \
-          php7.2-enchant \
-          php7.2-fpm \
-          php7.2-gd \
-          php7.2-gmp \
-          php7.2-imap \
-          php7.2-interbase \
-          php7.2-intl \
-          php7.2-json \
-          php7.2-ldap \
-          php7.2-mbstring \
-          php7.1-mcrypt \
-          php7.2-mysql \
-          php7.2-odbc \
-          php7.2-opcache \
-          php7.2-pgsql \
-          php7.2-phpdbg \
-          php7.2-pspell \
-          php7.2-readline \
-          php7.2-recode \
-          php7.2-snmp \
-          php7.2-sqlite3 \
-          php7.2-sybase \
-          php7.2-tidy \
-          php7.2-xmlrpc \
-          php7.2-xsl \
-          php7.2-zip
-        # Install webserver and database dependencies
-        sudo apt-get install -y apache2 libapache2-mod-php7.2 \
-          mariadb-common mariadb-server mariadb-client \
-          composer
-        # Install project with composer, and initialise the database
-        sudo service mysql start \
-          && cd $GITHUB_WORKSPACE \
-          && cat docker/cspot-mysql.sql | mysql \
-          && cp docker/.env.example .env \
-          && composer install \
-          && php artisan key:generate \
-          && echo "admin@example.com" | php artisan migrate
+        sudo docker build .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,26 +8,71 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
-    # Runs a single command using the runners shell
-    - name: Run a one-line script
-      run: echo Hello, world!
-
     # Runs a set of commands using the runners shell
     - name: Run a multi-line script
       run: |
-        echo Add other actions to build,
-        echo test, and deploy your project.
+        # Update apt and add needed repository
+        sudo apt-get update && sudo apt-get upgrade -y
+        sudo apt-get install -y python-software-properties software-properties-common apt-utils \
+          && LC_ALL=C.UTF-8 sudo add-apt-repository ppa:ondrej/php \
+          && sudo apt-get update
+        # Install project dependencies
+        sudo apt-get install -y \
+          php7.2 \
+          php7.2-bz2 \
+          php7.2-cgi \
+          php7.2-cli \
+          php7.2-common \
+          php7.2-curl \
+          php7.2-dev \
+          php7.2-enchant \
+          php7.2-fpm \
+          php7.2-gd \
+          php7.2-gmp \
+          php7.2-imap \
+          php7.2-interbase \
+          php7.2-intl \
+          php7.2-json \
+          php7.2-ldap \
+          php7.2-mbstring \
+          php7.1-mcrypt \
+          php7.2-mysql \
+          php7.2-odbc \
+          php7.2-opcache \
+          php7.2-pgsql \
+          php7.2-phpdbg \
+          php7.2-pspell \
+          php7.2-readline \
+          php7.2-recode \
+          php7.2-snmp \
+          php7.2-sqlite3 \
+          php7.2-sybase \
+          php7.2-tidy \
+          php7.2-xmlrpc \
+          php7.2-xsl \
+          php7.2-zip
+        # Install webserver and database dependencies
+        sudo apt-get install -y apache2 libapache2-mod-php7.2 \
+          mariadb-common mariadb-server mariadb-client \
+          composer
+        # Install project with composer, and initialise the database
+        sudo service mysql start \
+          && cd $GITHUB_WORKSPACE \
+          && cat docker/cspot-mysql.sql | mysql \
+          && cp docker/.env.example .env \
+          && composer install \
+          && php artisan key:generate \
+          && echo "admin@example.com" | php artisan migrate


### PR DESCRIPTION
I have deleted the other PRs, since they were misleading and unhelpful in intent. The PR-triggered workflow was running on a merged-to-master commit, which was doomed to fail without upgrades to the dockerfile (I think). This PR is to integrate a new CI workflow to a known working version of laravel, version 5.8 - I've made a branch based on the commit where laravel was updated to 5.8. From there, we can begin a second PR to integrate this CI workflow with the newest version, 6.0.